### PR TITLE
improve `assertNotificationDetails`

### DIFF
--- a/Sources/XCTSpeziNotifications/XCUIApplication+NotificationDetails.swift
+++ b/Sources/XCTSpeziNotifications/XCUIApplication+NotificationDetails.swift
@@ -53,6 +53,8 @@ extension XCUIApplication {
         if let thread {
             XCTAssert(staticTexts["Thread, \(thread)"].exists)
         }
+        
+        swipeUp()
 
         XCTAssert(staticTexts["Sound, \(sound ? "Yes" : "No")"].exists)
         XCTAssert(staticTexts["Interruption, \(interruption.description)"].exists)
@@ -64,7 +66,6 @@ extension XCUIApplication {
         if let type {
             XCTAssert(staticTexts["Type, \(type)"].exists)
         }
-
 
         if let nextTrigger {
             XCTAssert(staticTexts["Next Trigger, \(nextTrigger)"].waitForExistence(timeout: nextTriggerExistenceTimeout))

--- a/Sources/XCTSpeziNotifications/XCUIApplication+NotificationDetails.swift
+++ b/Sources/XCTSpeziNotifications/XCUIApplication+NotificationDetails.swift
@@ -53,16 +53,14 @@ extension XCUIApplication {
         if let thread {
             XCTAssert(staticTexts["Thread, \(thread)"].exists)
         }
-        
-        #if !os(tvOS)
-        swipeUp()
-        #endif
 
         XCTAssert(staticTexts["Sound, \(sound ? "Yes" : "No")"].exists)
         XCTAssert(staticTexts["Interruption, \(interruption.description)"].exists)
 
         #if os(visionOS)
         staticTexts["Interruption, \(interruption.description)"].swipeUp(velocity: .fast)
+        #elseif !os(tvOS)
+        swipeUp()
         #endif
 
         if let type {

--- a/Sources/XCTSpeziNotifications/XCUIApplication+NotificationDetails.swift
+++ b/Sources/XCTSpeziNotifications/XCUIApplication+NotificationDetails.swift
@@ -54,14 +54,16 @@ extension XCUIApplication {
             XCTAssert(staticTexts["Thread, \(thread)"].exists)
         }
         
+        #if !os(tvOS)
         swipeUp()
+        #endif
 
         XCTAssert(staticTexts["Sound, \(sound ? "Yes" : "No")"].exists)
         XCTAssert(staticTexts["Interruption, \(interruption.description)"].exists)
 
-#if os(visionOS)
+        #if os(visionOS)
         staticTexts["Interruption, \(interruption.description)"].swipeUp(velocity: .fast)
-#endif
+        #endif
 
         if let type {
             XCTAssert(staticTexts["Type, \(type)"].exists)

--- a/Sources/XCTSpeziNotificationsUI/NotificationRequestView.swift
+++ b/Sources/XCTSpeziNotificationsUI/NotificationRequestView.swift
@@ -124,7 +124,9 @@ public struct NotificationRequestView: View {
                     Text("Type", bundle: .module)
                 }
                     .accessibilityElement(children: .combine)
-
+                if let trigger = trigger as? UNCalendarNotificationTrigger {
+                    LabeledContent("Date", value: trigger.dateComponents.description)
+                }
                 if let nextDate = trigger.nextDate() {
                     LabeledContent("Next Trigger") {
                         NotificationTriggerLabel(nextDate)
@@ -134,6 +136,7 @@ public struct NotificationRequestView: View {
                             viewUpdate.schedule(at: nextDate)
                         }
                 }
+                LabeledContent("Repeats", value: "\(trigger.repeats)")
             } header: {
                 Text("Trigger", bundle: .module)
             }

--- a/Sources/XCTSpeziNotificationsUI/PendingNotificationsList.swift
+++ b/Sources/XCTSpeziNotificationsUI/PendingNotificationsList.swift
@@ -76,7 +76,6 @@ public struct PendingNotificationsList: View {
         defer {
             viewState = .idle
         }
-
         pendingNotifications.removeAll()
         pendingNotifications = await localNotifications.pendingNotificationRequests()
     }

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -25,14 +25,18 @@ struct UITestsApp: App {
                         ControlsView()
                     }
                 }
-
                 Tab("Notifications", systemImage: "mail") {
                     NavigationStack {
                         NotificationsView()
                     }
                 }
             }
-                .spezi(appDelegate)
+            .spezi(appDelegate)
         }
+        // for some reason, XCTest can't swipeUp() in visionOS (you can call the function; it just doesn't do anything),
+        // so we instead need to make the window super large so that everything fits on screen without having to scroll.
+        #if os(visionOS)
+        .defaultSize(width: 1250, height: 1250)
+        #endif
     }
 }


### PR DESCRIPTION
# improve `assertNotificationDetails`

## :recycle: Current situation & Problem
- issue: in some cases if there's too much content on screen, the `assertNotificationDetails` function would be unable to find all of the content. we fix this by having it swipe down in the middle of the test. (previously, the caller would in some cases swipe down before calling `assertNotificationDetails`, which would in turn cause it to not find the topmost content)
- there's some notification request-related content which currently isn't included in the view but might be useful

## :gear: Release Notes 
- improved `assertNotificationDetails` reliability by making it swipe down when needed. Callers should no longer call `swipeDown()` before calling `assertNotificationDetails`.
- added some extra fields to the `NotificationRequestView`

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a; this PR changs the testing support code itself

## :pencil: Code of Conduct & Contributing Guidelines 
By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
