### PR TITLE
try to fix crashes when accessing the `UNUserNotificationCenter` in a unit test

### DIFF
--- a/Sources/SpeziNotifications/Notifications.swift
+++ b/Sources/SpeziNotifications/Notifications.swift
@@ -14,6 +14,8 @@ import Spezi
 ///
 /// This module provides some easy to use API to schedule and manage local notifications.
 ///
+/// - Note: The `Notification` module is not functional during unit tests; in this case all operations will silently fail.
+///
 /// ## Topics
 ///
 /// ### Configuration

--- a/Tests/SpeziNotificationsTests/NotificationsModuleUnitTestBehaviour.swift
+++ b/Tests/SpeziNotificationsTests/NotificationsModuleUnitTestBehaviour.swift
@@ -1,0 +1,28 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziNotifications
+import Testing
+import UserNotifications
+
+
+@Suite
+struct NotificationsModuleUnitTestBehaviour {
+    @Test
+    @MainActor
+    func testNotificationsModuleIsNonFunctional() async throws {
+        let module = Notifications()
+        try await module.setBadgeCount(12)
+        try await module.add(request: UNNotificationRequest(identifier: "abc", content: UNMutableNotificationContent(), trigger: nil))
+        #expect(try await module.remainingNotificationLimit() == 0)
+        #expect(await module.pendingNotificationRequests() == [])
+        #expect(await module.deliveredNotifications() == [])
+        await module.add(categories: [UNNotificationCategory(identifier: "abc", actions: [], intentIdentifiers: [])])
+        await module.removePendingNotificationRequests(where: { _ in true })
+    }
+}

--- a/Tests/SpeziNotificationsTests/NotificationsModuleUnitTestBehaviour.swift
+++ b/Tests/SpeziNotificationsTests/NotificationsModuleUnitTestBehaviour.swift
@@ -17,12 +17,16 @@ struct NotificationsModuleUnitTestBehaviour {
     @MainActor
     func testNotificationsModuleIsNonFunctional() async throws {
         let module = Notifications()
+        #if !os(watchOS)
         try await module.setBadgeCount(12)
+        #endif
         try await module.add(request: UNNotificationRequest(identifier: "abc", content: UNMutableNotificationContent(), trigger: nil))
         #expect(try await module.remainingNotificationLimit() == 0)
         #expect(await module.pendingNotificationRequests().isEmpty)
+        #if !os(tvOS)
         #expect(await module.deliveredNotifications().isEmpty)
         await module.add(categories: [UNNotificationCategory(identifier: "abc", actions: [], intentIdentifiers: [])])
+        #endif
         await module.removePendingNotificationRequests(where: { _ in true })
     }
 }

--- a/Tests/SpeziNotificationsTests/NotificationsModuleUnitTestBehaviour.swift
+++ b/Tests/SpeziNotificationsTests/NotificationsModuleUnitTestBehaviour.swift
@@ -20,8 +20,8 @@ struct NotificationsModuleUnitTestBehaviour {
         try await module.setBadgeCount(12)
         try await module.add(request: UNNotificationRequest(identifier: "abc", content: UNMutableNotificationContent(), trigger: nil))
         #expect(try await module.remainingNotificationLimit() == 0)
-        #expect(await module.pendingNotificationRequests() == [])
-        #expect(await module.deliveredNotifications() == [])
+        #expect(await module.pendingNotificationRequests().isEmpty)
+        #expect(await module.deliveredNotifications().isEmpty)
         await module.add(categories: [UNNotificationCategory(identifier: "abc", actions: [], intentIdentifiers: [])])
         await module.removePendingNotificationRequests(where: { _ in true })
     }


### PR DESCRIPTION
# try to fix crashes when accessing the `UNUserNotificationCenter` in a unit test

## :recycle: Current situation & Problem
Issue: `+[UNUserNotificationCenter current]` isn't available when running without a host application. The method can still be called just fine in these cases, but it will simply always raise an `NSException`.
We attempt to work around this, by disabling large parts of SpeziNotifications when we detect that the module is being used from within a unit test.
In this scenario, all operations on the `Notifications` module will simply not do anything.

This is fine, since there isn't much of a point in trying to use local notifications in non-UI unit tests in the first place.
(eg: you can't even ask for notification permissions in the first place, so all of these operations would typically fail anyway.)

Note that these changes only affect unit tests; UI tests will continue to work as normal.

At this point, one might ask but Lukas why do we need this change now, everything seems to have worked fine in the past.
And to that i can only say: i don't know either. My guess is that we've simply been lucky so far, in that the main SpeziNotifications user (SpeziScheduler) doesn't have any unit tests that schedule tasks with notifications, and as a result we probably just somehow avoided running into this issue before.

There are some additional places in the package that access the current UNUserNotificationCenter, namely the `LegacyTaskModel` and the `RegisterRemoteNotificationsAction`. Both of these remain unchanged; the first since it's currently unused, and the second since it isn't really accessible from within a unit test.


## :gear: Release Notes
- added detection for unit tests, in which case the functionality of the `Notifications` module will be disabled, and all operations will silently fail

## :books: Documentation
the new behaviour is documented.


## :white_check_mark: Testing
we have a new test case to verify the new behaviour (ie, that nothing happens, ie, that using the `Notifications` module from w/in a unit test doesn't cause a crash)


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
