### PR TITLE
expose `requestNotificationAuthorization` retval

### DIFF
--- a/Sources/SpeziNotifications/Actions/RequestNotificationAuthorization.swift
+++ b/Sources/SpeziNotifications/Actions/RequestNotificationAuthorization.swift
@@ -19,8 +19,9 @@ extension Spezi {
         fileprivate init() {}
 
         /// Request notification authorization.
-        /// - Parameter options: The authorization options your app is requesting.
-        public func callAsFunction(options: UNAuthorizationOptions) async throws {
+        /// - parameter options: The authorization options your app is requesting.
+        /// - returns: A Boolean value indicating whether the user granted the requested permissions.
+        public func callAsFunction(options: UNAuthorizationOptions) async throws -> Bool {
             try await UNUserNotificationCenter.current().requestAuthorization(options: options)
         }
     }

--- a/Sources/XCTSpeziNotificationsUI/NotificationsView.swift
+++ b/Sources/XCTSpeziNotificationsUI/NotificationsView.swift
@@ -31,7 +31,7 @@ public struct NotificationsView: View {
             .toolbar {
                 if requestAuthorization {
                     AsyncButton(state: $viewState) {
-                        try await requestNotificationAuthorization(options: [.alert, .sound, .badge])
+                        _ = try await requestNotificationAuthorization(options: [.alert, .sound, .badge])
                         await queryAuthorization()
                         authorizationAction()
                     } label: {


### PR DESCRIPTION
# expose `requestNotificationAuthorization` retval

## :recycle: Current situation & Problem
The `requestNotificationAuthorization` action currently returns void, even though the `requestAuthorization(options:)` function it calls internally has a `Bool` retval, and even though there are code samples in the documentation that demonstrate using `requestNotificationAuthorization` in a boolean-expecting context.
This PR fixes this, by properly forwarding the return value.


## :gear: Release Notes
- changed `requestNotificationAuthorization` to return a boolean value indicating whether the requested permissions were granted.


## :books: Documentation
updated


## :white_check_mark: Testing
updated


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
