### PR TITLE
add a `nextTriggerDate` tracking mechanism

### DIFF
--- a/Sources/SpeziNotifications/Notifications.swift
+++ b/Sources/SpeziNotifications/Notifications.swift
@@ -102,7 +102,7 @@ public final class Notifications: Module, DefaultInitializable, EnvironmentAcces
             return
         }
         if let mutableContent = request.content.mutableCopy() as? UNMutableNotificationContent {
-            mutableContent.setUserInfoValue(Date(), for: Self.notificationContentUserInfoKeyScheduledDate)
+            mutableContent.scheduledDate = .now
             try await notificationCenter.add(UNNotificationRequest(
                 identifier: request.identifier,
                 content: mutableContent,
@@ -201,6 +201,10 @@ extension UNNotificationContent {
         nil
         #endif
     }
+    
+    @objc package var scheduledDate: Date? {
+        userInfoValue(for: Notifications.notificationContentUserInfoKeyScheduledDate, as: Date.self)
+    }
 }
 
 extension UNMutableNotificationContent {
@@ -208,6 +212,15 @@ extension UNMutableNotificationContent {
         #if !os(tvOS)
         userInfo[key] = value
         #endif
+    }
+    
+    @objc override package var scheduledDate: Date? {
+        get {
+            super.scheduledDate
+        }
+        set {
+            setUserInfoValue(newValue, for: Notifications.notificationContentUserInfoKeyScheduledDate)
+        }
     }
 }
 

--- a/Sources/SpeziNotifications/Notifications.swift
+++ b/Sources/SpeziNotifications/Notifications.swift
@@ -44,7 +44,9 @@ public final class Notifications: Module, DefaultInitializable, EnvironmentAcces
     public static let pendingNotificationsLimit = 64
     
     /// The `Date` when the notification request was scheduled.
-    public static let notificationContentUserInfoKeyScheduleDate = "edu.stanford.SpeziNotifications.notificationScheduleDate"
+    ///
+    /// - Note: This is the `Date` when the request was registered with the notification center, not the `Date` for which the request was scheduled.
+    public static let notificationContentUserInfoKeyScheduledDate = "edu.stanford.SpeziNotifications.notificationScheduledDate"
     // swiftlint:disable:previous identifier_name
 
     @Application(\.notificationSettings)
@@ -100,7 +102,7 @@ public final class Notifications: Module, DefaultInitializable, EnvironmentAcces
             return
         }
         if let mutableContent = request.content.mutableCopy() as? UNMutableNotificationContent {
-            mutableContent.userInfo[Self.notificationContentUserInfoKeyScheduleDate] = Date()
+            mutableContent.userInfo[Self.notificationContentUserInfoKeyScheduledDate] = Date()
             try await notificationCenter.add(UNNotificationRequest(
                 identifier: request.identifier,
                 content: mutableContent,

--- a/Sources/SpeziNotifications/Notifications.swift
+++ b/Sources/SpeziNotifications/Notifications.swift
@@ -102,7 +102,7 @@ public final class Notifications: Module, DefaultInitializable, EnvironmentAcces
             return
         }
         if let mutableContent = request.content.mutableCopy() as? UNMutableNotificationContent {
-            mutableContent.userInfo[Self.notificationContentUserInfoKeyScheduledDate] = Date()
+            mutableContent.setUserInfoValue(Date(), for: Self.notificationContentUserInfoKeyScheduledDate)
             try await notificationCenter.add(UNNotificationRequest(
                 identifier: request.identifier,
                 content: mutableContent,
@@ -189,3 +189,25 @@ public final class Notifications: Module, DefaultInitializable, EnvironmentAcces
         notificationCenter.removePendingNotificationRequests(withIdentifiers: identifiers)
     }
 }
+
+
+// MARK: Utils
+
+extension UNNotificationContent {
+    package func userInfoValue<T>(for key: String, as _: T.Type) -> T? {
+        #if !os(tvOS)
+        userInfo[key] as? T
+        #else
+        nil
+        #endif
+    }
+}
+
+extension UNMutableNotificationContent {
+    package func setUserInfoValue(_ value: some Any, for key: String) {
+        #if !os(tvOS)
+        userInfo[key] = value
+        #endif
+    }
+}
+

--- a/Sources/SpeziNotifications/Notifications.swift
+++ b/Sources/SpeziNotifications/Notifications.swift
@@ -42,6 +42,10 @@ public final class Notifications: Module, DefaultInitializable, EnvironmentAcces
     ///
     /// The limit is `64`.
     public static let pendingNotificationsLimit = 64
+    
+    /// The `Date` when the notification request was scheduled.
+    public static let notificationContentUserInfoKeyScheduleDate = "edu.stanford.SpeziNotifications.notificationScheduleDate"
+    // swiftlint:disable:previous identifier_name
 
     @Application(\.notificationSettings)
     public var notificationSettings
@@ -95,7 +99,16 @@ public final class Notifications: Module, DefaultInitializable, EnvironmentAcces
         guard let notificationCenter else {
             return
         }
-        try await notificationCenter.add(request)
+        if let mutableContent = request.content.mutableCopy() as? UNMutableNotificationContent {
+            mutableContent.userInfo[Self.notificationContentUserInfoKeyScheduleDate] = Date()
+            try await notificationCenter.add(UNNotificationRequest(
+                identifier: request.identifier,
+                content: mutableContent,
+                trigger: request.trigger
+            ))
+        } else {
+            try await notificationCenter.add(request)
+        }
     }
 
     /// Retrieve the amount of notifications that can be scheduled for the app.

--- a/Sources/SpeziNotifications/Notifications.swift
+++ b/Sources/SpeziNotifications/Notifications.swift
@@ -194,6 +194,10 @@ public final class Notifications: Module, DefaultInitializable, EnvironmentAcces
 // MARK: Utils
 
 extension UNNotificationContent {
+    @objc package var scheduledDate: Date? {
+        userInfoValue(for: Notifications.notificationContentUserInfoKeyScheduledDate, as: Date.self)
+    }
+    
     package func userInfoValue<T>(for key: String, as _: T.Type) -> T? {
         #if !os(tvOS)
         userInfo[key] as? T
@@ -201,20 +205,10 @@ extension UNNotificationContent {
         nil
         #endif
     }
-    
-    @objc package var scheduledDate: Date? {
-        userInfoValue(for: Notifications.notificationContentUserInfoKeyScheduledDate, as: Date.self)
-    }
 }
 
 extension UNMutableNotificationContent {
-    package func setUserInfoValue(_ value: some Any, for key: String) {
-        #if !os(tvOS)
-        userInfo[key] = value
-        #endif
-    }
-    
-    @objc override package var scheduledDate: Date? {
+    @objc override package var scheduledDate: Date? { // swiftlint:disable:this override_in_extension
         get {
             super.scheduledDate
         }
@@ -222,5 +216,10 @@ extension UNMutableNotificationContent {
             setUserInfoValue(newValue, for: Notifications.notificationContentUserInfoKeyScheduledDate)
         }
     }
+    
+    package func setUserInfoValue(_ value: some Any, for key: String) {
+        #if !os(tvOS)
+        userInfo[key] = value
+        #endif
+    }
 }
-

--- a/Sources/XCTSpeziNotificationsUI/NotificationRequestLabel.swift
+++ b/Sources/XCTSpeziNotificationsUI/NotificationRequestLabel.swift
@@ -28,8 +28,7 @@ struct NotificationRequestLabel: View {
                 Text(request.content.title)
                     .bold()
 #endif
-                if let trigger = request.trigger,
-                   let nextDate = trigger.nextDate() {
+                if let nextDate = request.nextTriggerDate() {
                     NotificationTriggerLabel(nextDate)
                         .foregroundStyle(.secondary)
                         .onAppear {

--- a/Sources/XCTSpeziNotificationsUI/NotificationRequestView.swift
+++ b/Sources/XCTSpeziNotificationsUI/NotificationRequestView.swift
@@ -127,7 +127,7 @@ public struct NotificationRequestView: View {
                 if let trigger = trigger as? UNCalendarNotificationTrigger {
                     LabeledContent("Date", value: trigger.dateComponents.description)
                 }
-                if let nextDate = trigger.nextDate() {
+                if let nextDate = request.nextTriggerDate() {
                     LabeledContent("Next Trigger") {
                         NotificationTriggerLabel(nextDate)
                     }

--- a/Sources/XCTSpeziNotificationsUI/Resources/Localizable.xcstrings
+++ b/Sources/XCTSpeziNotificationsUI/Resources/Localizable.xcstrings
@@ -51,6 +51,9 @@
         }
       }
     },
+    "Date" : {
+
+    },
     "Delivery" : {
       "localizations" : {
         "en" : {
@@ -190,6 +193,9 @@
           }
         }
       }
+    },
+    "Repeats" : {
+
     },
     "Request Notification Authorization" : {
       "localizations" : {

--- a/Sources/XCTSpeziNotificationsUI/UNNotificationTrigger+Extensions.swift
+++ b/Sources/XCTSpeziNotificationsUI/UNNotificationTrigger+Extensions.swift
@@ -47,14 +47,14 @@ extension UNNotificationRequest {
             // this happens because the trigger itself exists completely independent of the
             // notification request it belongs to. additionally, since there's no way to obtain
             // the time a notification request was scheduled, we need to keep track of this manually.
-            if let scheduledDate = content.userInfoValue(for: Notifications.notificationContentUserInfoKeyScheduledDate, as: Date.self) {
+            if let scheduledDate = content.scheduledDate {
                 scheduledDate.addingTimeInterval(trigger.timeInterval)
             } else {
                 nil
             }
         } else if trigger == nil {
             // if there is no trigger, the notification gets delivered immediately; in this case the trigger date would equal the schedule date
-            content.userInfoValue(for: Notifications.notificationContentUserInfoKeyScheduledDate, as: Date.self)
+            content.scheduledDate
         } else {
             // otherwise, we cannot obtain a trigger date.
             nil

--- a/Sources/XCTSpeziNotificationsUI/UNNotificationTrigger+Extensions.swift
+++ b/Sources/XCTSpeziNotificationsUI/UNNotificationTrigger+Extensions.swift
@@ -47,14 +47,14 @@ extension UNNotificationRequest {
             // this happens because the trigger itself exists completely independent of the
             // notification request it belongs to. additionally, since there's no way to obtain
             // the time a notification request was scheduled, we need to keep track of this manually.
-            if let scheduledDate = content.userInfo[Notifications.notificationContentUserInfoKeyScheduledDate] as? Date {
+            if let scheduledDate = content.userInfoValue(for: Notifications.notificationContentUserInfoKeyScheduledDate, as: Date.self) {
                 scheduledDate.addingTimeInterval(trigger.timeInterval)
             } else {
                 nil
             }
         } else if trigger == nil {
             // if there is no trigger, the notification gets delivered immediately; in this case the trigger date would equal the schedule date
-            content.userInfo[Notifications.notificationContentUserInfoKeyScheduledDate] as? Date
+            content.userInfoValue(for: Notifications.notificationContentUserInfoKeyScheduledDate, as: Date.self)
         } else {
             // otherwise, we cannot obtain a trigger date.
             nil

--- a/Sources/XCTSpeziNotificationsUI/UNNotificationTrigger+Extensions.swift
+++ b/Sources/XCTSpeziNotificationsUI/UNNotificationTrigger+Extensions.swift
@@ -47,14 +47,14 @@ extension UNNotificationRequest {
             // this happens because the trigger itself exists completely independent of the
             // notification request it belongs to. additionally, since there's no way to obtain
             // the time a notification request was scheduled, we need to keep track of this manually.
-            if let scheduledDate = content.userInfo[Notifications.notificationContentUserInfoKeyScheduleDate] as? Date {
+            if let scheduledDate = content.userInfo[Notifications.notificationContentUserInfoKeyScheduledDate] as? Date {
                 scheduledDate.addingTimeInterval(trigger.timeInterval)
             } else {
                 nil
             }
         } else if trigger == nil {
             // if there is no trigger, the notification gets delivered immediately; in this case the trigger date would equal the schedule date
-            content.userInfo[Notifications.notificationContentUserInfoKeyScheduleDate] as? Date
+            content.userInfo[Notifications.notificationContentUserInfoKeyScheduledDate] as? Date
         } else {
             // otherwise, we cannot obtain a trigger date.
             nil


### PR DESCRIPTION
# add a `nextTriggerDate` tracking mechanism

## :recycle: Current situation & Problem
The XCTSpeziNotificationsUI target displays incorrect values for next trigger dates of notification requests that use `UNTimeIntervalNotificationTrigger`s.
This is caused by the fact that `-[UNTimeIntervalNotificationTrigger nextTriggerDate]` simply returns `Date.now + trigger.timeInterval`, i.e. does not take the actual time the request was scheduled into account at all.
We address this by introducing a mechanism that keeps track of the date each `UNNotificationRequest` scheduled through Spezi's `Notifications` module was scheduled, and use that metadata if available to compute accurate trigger dates.

## :gear: Release Notes
- fixed XCTSpeziNotificationsUI displaying inaccurate trigger dates for time interval-based notification requests.

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
